### PR TITLE
#37 Fixing the concurrency problem with two simul…

### DIFF
--- a/resource-pool/package.json
+++ b/resource-pool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ty-ras-extras/resource-pool-fp-ts",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "author": {
     "name": "Stanislav Muhametsin",
     "email": "346799+stazz@users.noreply.github.com",

--- a/resource-pool/src/administration.ts
+++ b/resource-pool/src/administration.ts
@@ -27,7 +27,7 @@ export const createRunEviction =
     return F.pipe(
       state.resources,
       A.reduceWithIndex<
-        pool.Resource<TResource> | undefined,
+        pool.ResourcePoolStateArrayItem<TResource>,
         EvictReduceState<TResource>
       >(
         { now: Date.now(), toBeEvicted: [], toBeRetained: [] },
@@ -43,7 +43,7 @@ export const createRunEviction =
             })
           ) {
             reduceState.toBeEvicted.push(r.resource);
-          } else {
+          } else if (r !== null) {
             reduceState.toBeRetained.push(r);
           }
           return reduceState;

--- a/resource-pool/src/factory.ts
+++ b/resource-pool/src/factory.ts
@@ -64,7 +64,8 @@ const _createResourcePool = <TResource>({
       release: pool.createRelease(state),
     },
     administration: {
-      getCurrentResourceCount: () => state.resources.length,
+      getCurrentResourceCount: () =>
+        pool.getCurrentResourceCount(state.resources),
       getMinCount: () => state.minCount,
       getMaxCount: () => state.maxCount,
       runEviction: admin.createRunEviction(state, destroy),

--- a/state/src/index.ts
+++ b/state/src/index.ts
@@ -1,6 +1,6 @@
 // Really waiting for that "export type *": https://github.com/microsoft/TypeScript/issues/37238
 // If we just do "export * from", our index.[m]js file ends up with "export" statement as well, thus causing runtime errors.
-// Another option is rename .d.ts files into .ts files and end up with a bunch of empty .[m]js files and index.[m]js exporting those - not very optimal either.export * from "./headers";
+// Another option is rename .d.ts files into .ts files and end up with a bunch of empty .[m]js files and index.[m]js exporting those - not very optimal either.
 export type {
   StateInfo,
   StateInfoOfKeys,


### PR DESCRIPTION
…taneously executing resource creation callbacks. When first one failed, the pool state modification after second callback caused the second resource to be lost.